### PR TITLE
Buffer-local mappings

### DIFF
--- a/ftplugin/colddeck.vim
+++ b/ftplugin/colddeck.vim
@@ -17,3 +17,23 @@ if get(b:, 'cdeck_autocalc', get(g:, 'cdeck_autocalc', 1))
   call colddeck#SetAutoCalc()
 endif
 
+"---------------
+" Mappings {{{1
+"---------------
+
+if !get(g:, 'cdeck_nomaps', 0)
+  nnoremap <buffer>  <silent>  <Localleader>x  :<C-u>CDCalc<cr>
+  nnoremap <buffer>  <silent>  <Localleader>c  :<C-u>CDClear<cr>
+  nnoremap <buffer>  <silent>  <Localleader>a  :<C-u>CDToggleAutocalc<cr>
+  nnoremap <buffer>  <silent>  <Localleader>A  :<C-u>CDAlignHidingComments<cr>
+
+  nnoremap <buffer>  <silent>  <Localleader>h  :<C-u>CDToggleHidingComments<cr>
+  nnoremap <buffer>  <silent>  <Localleader><
+        \ :<C-u>CDMoveRCol <C-r>=empty(v:count)? "-5" : v:count<cr><cr>
+  nnoremap <buffer>  <silent>  <Localleader>>
+        \ :<C-u>CDMoveRCol <C-r>=empty(v:count)? "+5" : v:count<cr><cr>
+  nnoremap <buffer>  <silent>  <Localleader>$  :<C-u>call search('\v^.*\zs\S\ze%<'.
+        \ (get(b:, "cdeck_rcol", get(g:, "cdeck_rcol", 78))+1) . 'v.',
+        \ '',
+        \ line('.'))<cr>
+endif

--- a/plugin/colddeck.vim
+++ b/plugin/colddeck.vim
@@ -43,27 +43,6 @@ command! -bar CDToggleHidingComments
       \| endif
 
 
-"---------------
-" Mappings {{{1
-"---------------
-
-if !get(g:, 'cdeck_nomaps', 0)
-  nnoremap <silent>  <Localleader>x  :<C-u>CDCalc<cr>
-  nnoremap <silent>  <Localleader>c  :<C-u>CDClear<cr>
-  nnoremap <silent>  <Localleader>a  :<C-u>CDToggleAutocalc<cr>
-  nnoremap <silent>  <Localleader>A  :<C-u>CDAlignHidingComments<cr>
-
-  nnoremap <silent>  <Localleader>h  :<C-u>CDToggleHidingComments<cr>
-  nnoremap <silent>  <Localleader><
-        \ :<C-u>CDMoveRCol <C-r>=empty(v:count)? "-5" : v:count<cr><cr>
-  nnoremap <silent>  <Localleader>>
-        \ :<C-u>CDMoveRCol <C-r>=empty(v:count)? "+5" : v:count<cr><cr>
-  nnoremap <silent>  <Localleader>$  :<C-u>call search('\v^.*\zs\S\ze%<'.
-        \ (get(b:, "cdeck_rcol", get(g:, "cdeck_rcol", 78))+1) . 'v.',
-        \ '',
-        \ line('.'))<cr>
-endif
-
 
 "---------------
 " Autocmds {{{1


### PR DESCRIPTION
From what I can see, the mappings only makes sense in a colddeck file -- I've accidentally triggered them in other filetypes and I'd like to avoid that.

Defining them in the ftplugin and adding the `<buffer>` modifier should fix the issue.